### PR TITLE
Use init-d-script for the init script

### DIFF
--- a/src/bin/dbab
+++ b/src/bin/dbab
@@ -1,40 +1,19 @@
 #! /bin/sh
-# /etc/init.d/dbab
-#
-
-# Ref: https://wiki.debian.org/LSBInitScripts
+# kFreeBSD do not accept scripts as interpreters, using #!/bin/sh and sourcing.
+if [ true != "$INIT_D_SCRIPT_SOURCED" ] ; then
+    set "$0" "$@"; INIT_D_SCRIPT_SOURCED=true . /lib/init/init-d-script
+fi
 ### BEGIN INIT INFO
 # Provides:          dbab
 # Required-Start:    $remote_fs $syslog
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: Start dbab-svr daemon at boot time
-# Description:       Enable service provided by dbab-svr daemon.
+# Short-Description: dbab
+# Description:       dnsmasq-based ad-blocking using pixelserv.
 ### END INIT INFO
 
-# http://lintian.debian.org/tags/init.d-script-does-not-source-init-functions.html
-. /lib/lsb/init-functions
+DESC="Description of the service"
+DAEMON=/usr/sbin/dbab-srv
 
-# Carry out specific functions when asked to by the system
-case "$1" in
-   start)
-     echo "Starting dbab pixel server"
-     /usr/sbin/dbab-svr &
-     ;;
-   stop)
-     echo "Stopping dbab pixel server"
-     killall dbab-svr
-     ;;
-   restart|force-reload)
-     echo "Restarting dbab pixel server"
-     $0 stop
-     $0 start
-     ;;
-   *)
-     echo "Usage: /etc/init.d/dbab {start|stop|restart}"
-     exit 1
-     ;;
-esac
-
-exit 0
+START_ARGS="--background --make-pidfile"

--- a/src/bin/dbab
+++ b/src/bin/dbab
@@ -13,7 +13,7 @@ fi
 # Description:       dnsmasq-based ad-blocking using pixelserv.
 ### END INIT INFO
 
-DESC="Description of the service"
+DESC="dnsmasq-based ad-blocker"
 DAEMON=/usr/sbin/dbab-srv
 
 START_ARGS="--background --make-pidfile"


### PR DESCRIPTION
This fixes a few issues where errors were not being reported correctly for the start and stop actions, as well as simplifies the init script immensely.
